### PR TITLE
stdint.h 헤더 추가

### DIFF
--- a/src/kernel/dc.h
+++ b/src/kernel/dc.h
@@ -35,8 +35,10 @@
 typedef unsigned int uint32;
 typedef unsigned int uint32_t;
 typedef unsigned char uint8;
+typedef unsigned char uint8_t;
 typedef unsigned long long size_t;
 typedef unsigned short uint16;  // ELF 헤더 파싱용
+typedef unsigned short uint16_t;
 
 /*=========================*/
 /* 6. ELF Header (단순화, 32비트) */

--- a/src/kernel/disk.c
+++ b/src/kernel/disk.c
@@ -1,5 +1,4 @@
 #include "disk.h"
-#include <stdint.h>
 
 /* I/O 포트 접근을 위한 인라인 어셈블리 */
 static inline uint8_t inb(uint16_t port) {

--- a/src/kernel/disk.c
+++ b/src/kernel/disk.c
@@ -1,4 +1,5 @@
 #include "disk.h"
+#include <stdint.h>
 
 /* I/O 포트 접근을 위한 인라인 어셈블리 */
 static inline uint8_t inb(uint16_t port) {


### PR DESCRIPTION
cygwin 또는 debian_sid에서 빌드 시도 시 `uint16_t` 에 대해 `note: ‘uint16_t’ is defined in header ‘<stdint.h>’; this is probably fixable by adding ‘#include <stdint.h>’` 에러 발생
